### PR TITLE
Fix accesslog and errorlog

### DIFF
--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -2,6 +2,6 @@ import multiprocessing
 
 bind = "0.0.0.0:8000"
 workers = multiprocessing.cpu_count() * 2 + 1
-errorlog = '/tmp/logs/gunicorn/access.log'
+accesslog = '/tmp/logs/gunicorn/access.log'
 loglevel = 'info'
-accesslog = '/tmp/logs/gunicorn/error.log'
+errorlog= '/tmp/logs/gunicorn/error.log'


### PR DESCRIPTION
The log types were erroneously swapped :evergreen_tree:. Fixed.